### PR TITLE
Misc redundant const refs

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -1,0 +1,18 @@
+name: Push Docker Image
+
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Build & Push
+        uses: jerray/publish-docker-action@master
+        with:
+          repository: jstrz/vt-clang-tidy
+          registry: docker.io
+          auto_tag: true
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -14,5 +14,6 @@ jobs:
           repository: jstrz/vt-clang-tidy
           registry: docker.io
           auto_tag: true
+          allow_pull_request: true
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:20.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y -q && apt-get install -y -q --no-install-recommends \
+    build-essential \
+    cmake \
+    git \
+    ninja-build \
+    python3 \
+    lld
+
+COPY . /llvm-project
+
+RUN mkdir llvm-build
+WORKDIR /llvm-build
+RUN cmake \
+    -DCLANG_TIDY_ENABLE_STATIC_ANALYZER=ON \
+    "-DLLVM_ENABLE_PROJECTS=clang;clang-tools-extra" \
+    -DLLVM_TARGETS_TO_BUILD=X86 \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/llvm-install \
+    -DLLVM_USE_LINKER=lld \
+    -GNinja \
+    /llvm-project/llvm
+RUN cmake --build . --target install
+
+FROM builder AS installer
+WORKDIR /
+COPY --from=builder /llvm-install/ /usr/local/

--- a/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
@@ -39,6 +39,7 @@ add_clang_library(clangTidyMiscModule
   NoRecursionCheck.cpp
   NonCopyableObjects.cpp
   NonPrivateMemberVariablesInClassesCheck.cpp
+  RedundantConstRefsCheck.cpp
   RedundantExpressionCheck.cpp
   StaticAssertCheck.cpp
   ThrowByValueCatchByReferenceCheck.cpp

--- a/clang-tools-extra/clang-tidy/misc/MiscTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/misc/MiscTidyModule.cpp
@@ -19,6 +19,7 @@
 #include "NoRecursionCheck.h"
 #include "NonCopyableObjects.h"
 #include "NonPrivateMemberVariablesInClassesCheck.h"
+#include "RedundantConstRefsCheck.h"
 #include "RedundantExpressionCheck.h"
 #include "StaticAssertCheck.h"
 #include "ThrowByValueCatchByReferenceCheck.h"
@@ -53,6 +54,8 @@ public:
         "misc-non-copyable-objects");
     CheckFactories.registerCheck<NonPrivateMemberVariablesInClassesCheck>(
         "misc-non-private-member-variables-in-classes");
+    CheckFactories.registerCheck<RedundantConstRefsCheck>(
+        "misc-redundant-const-refs");
     CheckFactories.registerCheck<RedundantExpressionCheck>(
         "misc-redundant-expression");
     CheckFactories.registerCheck<StaticAssertCheck>("misc-static-assert");

--- a/clang-tools-extra/clang-tidy/misc/RedundantConstRefsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/RedundantConstRefsCheck.cpp
@@ -76,13 +76,16 @@ void RedundantConstRefsCheck::check(const MatchFinder::MatchResult &Result) {
   if (ParmType->isIncompleteType()) {
     return;
   }
+
+  const auto ParmWidth = Result.Context->getTypeInfo(ParmType).Width;
+  if (ParmWidth <= 128) {
     const auto Hint =
         FixItHint::CreateReplacement(ConstRefParm->getSourceRange(),
                                      "const " + ParmType.getAsString() + " " +
                                          ConstRefParm->getNameAsString());
-    diag(ConstRefParm->getBeginLoc(), "passing small (%0 bits) variable by "
+    diag(ConstRefParm->getBeginLoc(), "passing %0 (%1 bits) variable by "
                                       "const ref, consider passing by value")
-        << ParmWidth << ConstRefParm << Hint;
+        << ParmType << ParmWidth << ConstRefParm << Hint;
   }
 }
 

--- a/clang-tools-extra/clang-tidy/misc/RedundantConstRefsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/RedundantConstRefsCheck.cpp
@@ -78,7 +78,7 @@ void RedundantConstRefsCheck::check(const MatchFinder::MatchResult &Result) {
   }
 
   const auto ParmWidth = Result.Context->getTypeInfo(ParmType).Width;
-  if (ParmWidth <= 128) {
+  if (ParmWidth <= 64) {
     const auto Hint =
         FixItHint::CreateReplacement(ConstRefParm->getSourceRange(),
                                      "const " + ParmType.getAsString() + " " +

--- a/clang-tools-extra/clang-tidy/misc/RedundantConstRefsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/RedundantConstRefsCheck.cpp
@@ -83,8 +83,8 @@ void RedundantConstRefsCheck::check(const MatchFinder::MatchResult &Result) {
         FixItHint::CreateReplacement(ConstRefParm->getSourceRange(),
                                      "const " + ParmType.getAsString() + " " +
                                          ConstRefParm->getNameAsString());
-    diag(ConstRefParm->getBeginLoc(), "passing %0 (%1 bits) variable by "
-                                      "const ref, consider passing by value")
+    diag(ConstRefParm->getBeginLoc(),
+         "passing %0 (%1 bits) by const ref, consider passing by value")
         << ParmType << ParmWidth << ConstRefParm << Hint;
   }
 }

--- a/clang-tools-extra/clang-tidy/misc/RedundantConstRefsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/RedundantConstRefsCheck.cpp
@@ -19,7 +19,8 @@ namespace misc {
 void RedundantConstRefsCheck::registerMatchers(MatchFinder *Finder) {
   auto ConstRefParm =
       parmVarDecl(hasType(qualType(lValueReferenceType(),
-                                   references(isConstQualified()))))
+                                   references(isConstQualified()))),
+                  unless(isExpansionInSystemHeader()))
           .bind("const-ref-parm");
 
   Finder->addMatcher(ConstRefParm, this);

--- a/clang-tools-extra/clang-tidy/misc/RedundantConstRefsCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/RedundantConstRefsCheck.h
@@ -1,0 +1,34 @@
+//===--- RedundantConstRefsCheck.h - clang-tidy -----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_REDUNDANTCONSTREFSCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_REDUNDANTCONSTREFSCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace misc {
+
+/// FIXME: Write a short description.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/misc/redundant-const-refs.html
+class RedundantConstRefsCheck : public ClangTidyCheck {
+public:
+  RedundantConstRefsCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace misc
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_REDUNDANTCONSTREFSCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -115,6 +115,11 @@ New checks
 
   Warns when using ``do-while`` loops.
 
+- New :doc:`misc-redundant-const-refs
+  <clang-tidy/checks/misc/redundant-const-refs>` check.
+
+  FIXME: add release notes.
+
 New check aliases
 ^^^^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/redundant-const-refs.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/redundant-const-refs.rst
@@ -1,0 +1,6 @@
+.. title:: clang-tidy - misc-redundant-const-refs
+
+misc-redundant-const-refs
+=========================
+
+FIXME: Describe what patterns does the check detect and why. Give examples.

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/redundant-const-refs.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/redundant-const-refs.cpp
@@ -1,47 +1,99 @@
 // RUN: %check_clang_tidy %s misc-redundant-const-refs %t
 
-// TODO (STRZ) - test not finished yet
-
-int foo1(const int &A) {
-  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'notAwesomeFunc' is insufficiently awesome
-  // CHECK-MESSAGES: :[[@LINE-2]]:6: note: insert 'awesome'
-  const int B = 2;
-  return A + B;
+int constRefInt(const int &I) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: passing 'int' (32 bits) by const ref, consider passing by value [misc-redundant-const-refs]
+  // CHECK-FIXES: const int I
+  constexpr int B = 2;
+  return I + B;
 }
 
-int bar2(const int A) {
-  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'notAwesomeFunc' is insufficiently awesome
-  // CHECK-MESSAGES: :[[@LINE-2]]:6: note: insert 'awesome'
-  const int B = 2;
-  return A + B;
+int constInt(const int I) {
+  constexpr int B = 2;
+  return I + B;
 }
 
-int foo3(int &A) {
-  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'notAwesomeFunc' is insufficiently awesome
-  // CHECK-MESSAGES: :[[@LINE-2]]:6: note: insert 'awesome'
+int refInt(int &A) {
   const int B = 2;
   return A + B;
 }
 
 template <typename TypeT>
-int foo4(const TypeT &T, const int &A) {
-  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'notAwesomeFunc' is insufficiently awesome
-  // CHECK-MESSAGES: :[[@LINE-2]]:6: note: insert 'awesome'
-  return T.val() + A;
+int constRefTConstRefInt(const TypeT &T, const int &I) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:42: warning: passing 'int' (32 bits) by const ref, consider passing by value [misc-redundant-const-refs]
+  // CHECK-FIXES: const int I
+  return T.val() + I;
 }
 
-struct BigStruct {
-  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'notAwesomeFunc' is insufficiently awesome
-  // CHECK-MESSAGES: :[[@LINE-2]]:6: note: insert 'awesome'
-  int Aa = 0;
-  int Bb = 0;
-  int Cc = 0;
-  int Dd = 0;
-  int Ee = 0;
+struct StructTwoInts {
+  int Aa;
+  int Bb;
 };
 
-int foo5(const BigStruct &Bs) {
-  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'notAwesomeFunc' is insufficiently awesome
-  // CHECK-MESSAGES: :[[@LINE-2]]:6: note: insert 'awesome'
-  return Bs.Aa - Bs.Bb + Bs.Cc + Bs.Dd + Bs.Ee;
+int constRefStructTwoInts(const StructTwoInts &Sti) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: passing 'StructTwoInts' (64 bits) by const ref, consider passing by value [misc-redundant-const-refs]
+  // CHECK-FIXES: const StructTwoInts Sti
+  return Sti.Aa - Sti.Bb;
 }
+
+struct StructFiveInts {
+  int Aa;
+  int Bb;
+  int Cc;
+  int Dd;
+  int Ee;
+};
+
+int constRefStructFiveInts(const StructFiveInts &Sfi) {
+  return Sfi.Aa - Sfi.Bb + Sfi.Cc - Sfi.Dd + Sfi.Ee;
+}
+
+template <typename TypeT> struct DependentStruct {
+public:
+  DependentStruct(const TypeT &T) : T{T} {}
+  int asInt() const { return T.asInt(); }
+
+private:
+  const TypeT T;
+};
+
+// Ignore template functions
+template <typename TypeT>
+int constDependentStruct(const DependentStruct<TypeT> &Ds) {
+  return Ds.asInt();
+}
+
+template <> struct DependentStruct<int> {
+public:
+  DependentStruct(int I) : I{I} {}
+  int asInt() const { return I; }
+
+private:
+  const int I;
+};
+
+// Ignore template function specialization
+template <> int constDependentStruct<int>(const DependentStruct<int> &Ds) {
+  return Ds.asInt();
+}
+
+int constDependentStruct(const DependentStruct<int> &Ds) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: passing 'DependentStruct<int>' (32 bits) by const ref, consider passing by value [misc-redundant-const-refs]
+  // CHECK-FIXES: const DependentStruct<int> Ds
+  return Ds.asInt();
+}
+
+// TODO (STRZ):
+// Lambda's copy constructor should be ignore.
+// Look at `dyn_cast_or_null<CXXConstructorDecl>(FuncDecl)`
+bool isDone(const bool IsNotDone) {
+  auto Fn = [IsNotDone] { return not IsNotDone; };
+  return Fn();
+}
+
+// TOOD (STRZ): that should produce warning, but is ignored because of
+// const auto *FuncDecl =
+//     dyn_cast_or_null<FunctionDecl>(ConstRefParm->getParentFunctionOrMethod());
+// if (!FuncDecl) {
+//   return;
+// }
+// using SomeFunction = std::function<void(const int&)>;

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/redundant-const-refs.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/redundant-const-refs.cpp
@@ -1,0 +1,47 @@
+// RUN: %check_clang_tidy %s misc-redundant-const-refs %t
+
+// TODO (STRZ) - test not finished yet
+
+int foo1(const int &A) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'notAwesomeFunc' is insufficiently awesome
+  // CHECK-MESSAGES: :[[@LINE-2]]:6: note: insert 'awesome'
+  const int B = 2;
+  return A + B;
+}
+
+int bar2(const int A) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'notAwesomeFunc' is insufficiently awesome
+  // CHECK-MESSAGES: :[[@LINE-2]]:6: note: insert 'awesome'
+  const int B = 2;
+  return A + B;
+}
+
+int foo3(int &A) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'notAwesomeFunc' is insufficiently awesome
+  // CHECK-MESSAGES: :[[@LINE-2]]:6: note: insert 'awesome'
+  const int B = 2;
+  return A + B;
+}
+
+template <typename TypeT>
+int foo4(const TypeT &T, const int &A) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'notAwesomeFunc' is insufficiently awesome
+  // CHECK-MESSAGES: :[[@LINE-2]]:6: note: insert 'awesome'
+  return T.val() + A;
+}
+
+struct BigStruct {
+  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'notAwesomeFunc' is insufficiently awesome
+  // CHECK-MESSAGES: :[[@LINE-2]]:6: note: insert 'awesome'
+  int Aa = 0;
+  int Bb = 0;
+  int Cc = 0;
+  int Dd = 0;
+  int Ee = 0;
+};
+
+int foo5(const BigStruct &Bs) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'notAwesomeFunc' is insufficiently awesome
+  // CHECK-MESSAGES: :[[@LINE-2]]:6: note: insert 'awesome'
+  return Bs.Aa - Bs.Bb + Bs.Cc + Bs.Dd + Bs.Ee;
+}


### PR DESCRIPTION
Related to https://github.com/DARMA-tasking/vt/issues/874

---

## How to build this check
See `Dockerfile` for general reference on how to build the LLVM.

## Testing
Code snippets used for `misc-redundant-const-refs` testing can be found in:
`clang-tools-extra/test/clang-tidy/checkers/misc/redundant-const-refs.cpp`

To run `misc-redundant-const-refs` test:
```sh
cd clang-tools-extra/test/clang-tidy
export PATH=<llvm-installation-path>/bin/:$PATH
python3 check_clang_tidy.py checkers/misc/redundant-const-refs.cpp misc-redundant-const-refs tmp
```

`export PATH` makes sure that compiled clang-tidy 1) is in the path, 2) will be found before system clang-tidy (if exists).

In case of an error `No such file or directory: 'FileCheck'`, copy `FileCheck` from `<llvm-build-path>/bin` to `<llvm-installation-path>/bin`